### PR TITLE
Fix location bias wrong constructor on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.0] - 2019-07-30
+
+* Fixed wrong mapping of location bias on Android (north was swapped with south)
+
 ## [2.0.2+1] - 2019-06-03
 
 * Fixed Kotlin Smart Cast not working on certain setups.

--- a/android/src/main/kotlin/com/theantimony/googleplacespicker/GooglePlacesPickerPlugin.kt
+++ b/android/src/main/kotlin/com/theantimony/googleplacespicker/GooglePlacesPickerPlugin.kt
@@ -98,16 +98,16 @@ class GooglePlacesPickerPlugin() : MethodCallHandler, PluginRegistry.ActivityRes
 
         bias?.let {
             val locationBias = RectangularBounds.newInstance(
-                    LatLng(it["northEastLat"] ?: 0.0, it["northEastLng"] ?: 0.0),
-                    LatLng(it["southWestLat"] ?: 0.0, it["southWestLng"] ?: 0.0)
+                    LatLng(it["southWestLat"] ?: 0.0, it["southWestLng"] ?: 0.0),
+                    LatLng(it["northEastLat"] ?: 0.0, it["northEastLng"] ?: 0.0)
             )
             intentBuilder = intentBuilder.setLocationBias(locationBias)
         }
 
         restriction?.let {
             val locationRestriction = RectangularBounds.newInstance(
-                    LatLng(it["northEastLat"] ?: 0.0, it["northEastLng"] ?: 0.0),
-                    LatLng(it["southWestLat"] ?: 0.0, it["southWestLng"] ?: 0.0)
+                    LatLng(it["southWestLat"] ?: 0.0, it["southWestLng"] ?: 0.0),
+                    LatLng(it["northEastLat"] ?: 0.0, it["northEastLng"] ?: 0.0)
             )
             intentBuilder = intentBuilder.setLocationRestriction(locationRestriction)
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_picker
 description: Flutter plugin for Google Places and Autocomplete.
-version: 2.0.2+1
+version: 2.1.0
 author: Alexandru Tuca <salexandru.tuca@outlook.com>
 homepage: https://github.com/derTuca/flutter_google_places_picker
 


### PR DESCRIPTION
According to [documentation](https://developers.google.com/places/android-sdk/reference/com/google/android/libraries/places/api/model/RectangularBounds) a proper contructor takes firstly sothern points i.e. `RectangularBounds.newInstance(LatLng southwest, LatLng northeast)`.

Fixed that and bumped version to `2.1.0`